### PR TITLE
Passing $isErrorSensitive param to rEngine::run

### DIFF
--- a/src/Kachkaev/PHPR/RCore.php
+++ b/src/Kachkaev/PHPR/RCore.php
@@ -15,7 +15,7 @@ class RCore
     
     public function run($rCode, $resultAsArray = false, $isErrorSensitive = false)
     {
-        return $this->rEngine->run($rCode, $resultAsArray);
+        return $this->rEngine->run($rCode, $resultAsArray, $isErrorSensitive);
     }
     
     public function createInteractiveProcess($isErrorSensitive = false)


### PR DESCRIPTION
While working on a solution for using this library on a Windows machine, I found that $isErrorSensitive wasn't being passed properly to rEngine::run.