### PR TITLE
Invalid psr-4 namespacing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.3.9"
     },
     "autoload": {
-        "psr-4": {
+        "psr-0": {
             "Kachkaev\\PHPR\\": "src"
         }
     },


### PR DESCRIPTION
Fixes #25 and pretty much fixes the library for anyone that wants to use it. Latest master is unusable without this fix, regardless of PHP version.

