### PR TITLE
Fix condition error when reading stdout

### DIFF
--- a/src/Kachkaev/PHPR/Process/CommandLineRProcess.php
+++ b/src/Kachkaev/PHPR/Process/CommandLineRProcess.php
@@ -42,15 +42,15 @@ class CommandLineRProcess extends AbstractRProcess
             throw new RProcessException($errorOutput);
         }
 
-        // Do not terminate on errors
-        fwrite($this->pipes[0], "options(error=expression(NULL))\n");
-
         // Skip the startup message (if any)
         do {
             $out = fread($this->pipes[1], $this->infiniteLength);
             usleep($this->sleepTimeBetweenReads);
-        } while ($out != '> '
-                && substr($out, -3) != "\n> ");
+        } while ($out !== '> ' && substr($out, -3) !== "\n> ");
+
+        // Do not terminate on errors
+        fwrite($this->pipes[0], "options(error=expression(NULL))\n");
+        fread($this->pipes[1], $this->infiniteLength);
     }
 
     function doStop()

--- a/src/Kachkaev/PHPR/Process/CommandLineRProcess.php
+++ b/src/Kachkaev/PHPR/Process/CommandLineRProcess.php
@@ -78,7 +78,12 @@ class CommandLineRProcess extends AbstractRProcess
             fwrite($this->pipes[0], $rInputLine . "\n");
 
             // Read back the input
-            $currentCommandInput .= fread($this->pipes[1], $this->infiniteLength);
+            do {
+                $readLine = fread($this->pipes[1], $this->infiniteLength);
+            } while (trim($readLine) !== trim($rInputLine));
+            $currentCommandInput .= $readLine;
+
+            // Read the output
             $commandIsIncomplete = false;
             do {
                 $output = fread($this->pipes[1], $this->infiniteLength);


### PR DESCRIPTION
In some occurences, when reading the stdout buffer, the output can contain multiple lines at once.
I changed the conditions to take that case into account.

This PR will probably solve #14 and #18, 